### PR TITLE
Preserve comments and formatting in pubspec.yaml during version update

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -11,20 +11,42 @@ void main(List<String> args) {
 
   final parser = ArgParser()
     ..addCommand('') // No command name means this is the default command.
-    ..addFlag('git', defaultsTo: true, negatable: true, help: 'Run git commands: add, commit, tag and push.')
-    ..addFlag('any-branch', defaultsTo: false, negatable: false, help: 'Allow to run on any branch.')
-    ..addOption('branch', help: 'The branch to run on. Default is main or master.', valueHelp: 'branch_name')
-    ..addFlag('pubspec', defaultsTo: true, negatable: true, help: 'Update the pubspec.yaml file.')
+    ..addFlag('git',
+        defaultsTo: true,
+        negatable: true,
+        help: 'Run git commands: add, commit, tag and push.')
+    ..addFlag('any-branch',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Allow to run on any branch.')
+    ..addOption('branch',
+        help: 'The branch to run on. Default is main or master.',
+        valueHelp: 'branch_name')
+    ..addFlag('pubspec',
+        defaultsTo: true,
+        negatable: true,
+        help: 'Update the pubspec.yaml file.')
     ..addFlag('pubspec2dart',
-        defaultsTo: true, negatable: true, help: 'Create the pubspec.dart file on the lib/ of the project.')
-    ..addFlag('changelog', defaultsTo: true, negatable: true, help: 'Update the changelog.')
-    ..addFlag('tests', defaultsTo: true, negatable: true, help: 'Run dart tests.')
+        defaultsTo: true,
+        negatable: true,
+        help: 'Create the pubspec.dart file on the lib/ of the project.')
+    ..addFlag('changelog',
+        defaultsTo: true, negatable: true, help: 'Update the changelog.')
+    ..addFlag('tests',
+        defaultsTo: true, negatable: true, help: 'Run dart tests.')
     ..addFlag('fix', defaultsTo: true, negatable: true, help: 'Run dart fix.')
-    ..addFlag('format', defaultsTo: true, negatable: true, help: 'Run dart format.')
-    ..addFlag('analyze', defaultsTo: true, negatable: true, help: 'Run dart analyze.')
-    ..addFlag('publish', defaultsTo: true, negatable: true, help: 'Publish on pub.dev.')
-    ..addFlag('verbose', defaultsTo: true, negatable: true, help: 'Show verbose output.')
-    ..addFlag('version', abbr: 'v', negatable: false, help: 'Show the version of ${pubspec.name}.')
+    ..addFlag('format',
+        defaultsTo: true, negatable: true, help: 'Run dart format.')
+    ..addFlag('analyze',
+        defaultsTo: true, negatable: true, help: 'Run dart analyze.')
+    ..addFlag('publish',
+        defaultsTo: true, negatable: true, help: 'Publish on pub.dev.')
+    ..addFlag('verbose',
+        defaultsTo: true, negatable: true, help: 'Show verbose output.')
+    ..addFlag('version',
+        abbr: 'v',
+        negatable: false,
+        help: 'Show the version of ${pubspec.name}.')
     ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage help.');
 
   ArgResults argResults;
@@ -44,7 +66,9 @@ void main(List<String> args) {
   }
   final String version = argResults.rest.first;
 
-  final String message = argResults.rest.length < 2 ? 'Update version number' : argResults.rest.skip(1).join(' ');
+  final String message = argResults.rest.length < 2
+      ? 'Update version number'
+      : argResults.rest.skip(1).join(' ');
 
   final dpp = DartPubPublish(
       git: argResults['git'],

--- a/lib/exceptions/package_version_already_exists_exception.dart
+++ b/lib/exceptions/package_version_already_exists_exception.dart
@@ -4,7 +4,8 @@ class PackageVersionAlreadyExistsException implements Exception {
   final String message;
 
   PackageVersionAlreadyExistsException(Version version)
-      : message = 'The version $version already exists. Please choose a different version number.';
+      : message =
+            'The version $version already exists. Please choose a different version number.';
 
   @override
   String toString() => message;

--- a/lib/exceptions/pubspec_not_found.dart
+++ b/lib/exceptions/pubspec_not_found.dart
@@ -2,7 +2,8 @@ class PubspecNotFound implements Exception {
   final String message;
 
   PubspecNotFound(String path)
-      : message = 'The pubspec file at $path does not exist. Please check the path and try again.';
+      : message =
+            'The pubspec file at $path does not exist. Please check the path and try again.';
 
   @override
   String toString() => message;

--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -4,7 +4,6 @@ import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
 import 'package:dpp/exceptions/package_version_already_exists_exception.dart';
-import 'package:json2yaml/json2yaml.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
@@ -107,13 +106,16 @@ class DartPubPublish {
       analyze = true,
       pubPublish = true,
       verbose = true})
-      : _workingDir = workingDir != null ? Directory(workingDir) : Directory.current,
+      : _workingDir =
+            workingDir != null ? Directory(workingDir) : Directory.current,
         _pubspecFile = pubspecFile != null
             ? File(pubspecFile)
-            : File(path.join(workingDir ?? Directory.current.path, 'pubspec.yaml')),
+            : File(path.join(
+                workingDir ?? Directory.current.path, 'pubspec.yaml')),
         _changeLogFile = changeLogFile != null
             ? File(changeLogFile)
-            : File(path.join(workingDir ?? Directory.current.path, 'CHANGELOG.md')),
+            : File(path.join(
+                workingDir ?? Directory.current.path, 'CHANGELOG.md')),
         _get = pubGet,
         _git = git,
         _anyBranch = anyBranch,
@@ -156,16 +158,22 @@ class DartPubPublish {
   /// - [_git] Whether to commit and push the changes and tag the new version. Default is true.
   ///
   /// Throws a [PackageVersionAlreadyExistsException] if the package version already exists on pub.dev.
-  Future<void> run(String version, {String message = 'Update version number'}) async {
+  Future<void> run(String version,
+      {String message = 'Update version number'}) async {
     String? oldChangeLogContents;
     String oldPubspecContents = _pubspecFile.readAsStringSync();
-    File pubspec2dartFile = File(path.join(_workingDir.path, 'lib', 'pubspec.dart'));
+    File pubspec2dartFile =
+        File(path.join(_workingDir.path, 'lib', 'pubspec.dart'));
     String? oldPubspec2dartContents =
-        _pubspec2dart && pubspec2dartFile.existsSync() ? pubspec2dartFile.readAsStringSync() : null;
+        _pubspec2dart && pubspec2dartFile.existsSync()
+            ? pubspec2dartFile.readAsStringSync()
+            : null;
     final yaml = loadYaml(oldPubspecContents);
     final oldVersion = Version.parse(yaml['version']);
     Version newVersion;
-    bool changedChangeLog = false, changedPubspec = false, changedPubspec2dart = false;
+    bool changedChangeLog = false,
+        changedPubspec = false,
+        changedPubspec2dart = false;
 
     try {
       newVersion = Version.parse(version);
@@ -197,12 +205,13 @@ class DartPubPublish {
     if (_pubspec) {
       // Replace the version number in the pubspec.yaml file
       log('Updating version in pubspec.yaml...');
-      final updatedYaml = {...yaml, 'version': newVersion.toString()};
-      final jsonString = json.encode(updatedYaml);
-      final jsonMap = json.decode(jsonString);
-      final yamlString = json2yaml(jsonMap, yamlStyle: YamlStyle.pubspecYaml);
 
-      _pubspecFile.writeAsStringSync(yamlString);
+      final updatedPubspecContents = oldPubspecContents.replaceFirst(
+        RegExp(r'^version\s*:.*$', multiLine: true),
+        'version: $newVersion',
+      );
+
+      _pubspecFile.writeAsStringSync(updatedPubspecContents);
       log('Updated version in pubspec.yaml from $oldVersion to $newVersion');
       changedPubspec = true;
     }
@@ -249,7 +258,8 @@ class DartPubPublish {
         // Add the new version number and change log message to the head of the CHANGELOG.md file
         log('Updating CHANGELOG.md...');
         oldChangeLogContents = await _changeLogFile.readAsString();
-        final newContents = '## v$newVersion\n- $message\n$oldChangeLogContents';
+        final newContents =
+            '## v$newVersion\n- $message\n$oldChangeLogContents';
         await _changeLogFile.writeAsString(newContents);
         changedChangeLog = true;
       }
@@ -280,7 +290,9 @@ class DartPubPublish {
       }
 
       // Rollback the changes to the pubspec2dart file
-      if (_pubspec2dart && oldPubspec2dartContents != null && changedPubspec2dart) {
+      if (_pubspec2dart &&
+          oldPubspec2dartContents != null &&
+          changedPubspec2dart) {
         log('Rolling back changes to pubspec2dart...');
         pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
       }
@@ -313,7 +325,8 @@ class DartPubPublish {
   /// If the process exits with a non-zero exit code, a message indicating the exit code is printed to the console and
   /// the program is terminated with that exit code.
   Future<void> runCommand(String command, List<String> args) async {
-    final process = await Process.start(command, args, workingDirectory: _workingDir.path);
+    final process =
+        await Process.start(command, args, workingDirectory: _workingDir.path);
     process.stdout.transform(utf8.decoder).listen((data) {
       // Output the data as soon as it is received
       print(data);
@@ -347,8 +360,9 @@ class DartPubPublish {
   }
 
   Future<bool> isBranch(String? branch) async {
-    final ProcessResult result =
-        await Process.run('git', ['branch', '--show-current'], workingDirectory: _workingDir.path);
+    final ProcessResult result = await Process.run(
+        'git', ['branch', '--show-current'],
+        workingDirectory: _workingDir.path);
 
     final currentBranchName = result.stdout.trim();
 

--- a/test/dpp_test.dart
+++ b/test/dpp_test.dart
@@ -37,7 +37,7 @@ void main() {
           pubPublish: false);
       await publish.run('2.0.0', message: 'New feature');
       final updatedPubspec = pubspecFile.readAsStringSync();
-      final expectedPubspec = 'name: my_package\nversion: 2.0.0\n';
+      final expectedPubspec = 'name: my_package\nversion: 2.0.0';
       expect(updatedPubspec, expectedPubspec);
 
       final updatedChangeLog = changeLogFile.readAsStringSync();
@@ -61,7 +61,7 @@ void main() {
           pubPublish: false);
       await publish.run('major', message: 'New feature');
       final updatedPubspec = pubspecFile.readAsStringSync();
-      final expectedPubspec = 'name: my_package\nversion: 2.0.0\n';
+      final expectedPubspec = 'name: my_package\nversion: 2.0.0';
       expect(updatedPubspec, expectedPubspec);
 
       final updatedChangeLog = changeLogFile.readAsStringSync();

--- a/test/pubspec_preservation_test.dart
+++ b/test/pubspec_preservation_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+import 'package:dpp/src/dpp_base.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DartPubPublish - Pubspec Preservation', () {
+    late Directory tempDir;
+    late File pubspecFile;
+    late File changeLogFile;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp
+          .createTemp('pub_publish_test_preservation');
+      pubspecFile = File('${tempDir.path}/pubspec.yaml');
+      changeLogFile = File('${tempDir.path}/CHANGELOG.md');
+      await changeLogFile.writeAsString('');
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('updates version but preserves comments and formatting', () async {
+      final initialContent = '''
+name: my_package
+description: A description.
+# This is a comment
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+''';
+      await pubspecFile.writeAsString(initialContent);
+
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: false,
+          analyze: false,
+          format: false,
+          fix: false,
+          tests: false,
+          pubGet: false,
+          pubspec: true,
+          pubspec2dart: false,
+          pubPublish: false,
+          verbose: false);
+
+      await publish.run('1.0.1', message: 'Fix');
+
+      final updatedContent = pubspecFile.readAsStringSync();
+
+      // Check version update
+      expect(updatedContent, contains('version: 1.0.1'));
+
+      // Check comment preservation
+      expect(updatedContent, contains('# This is a comment'));
+
+      // Check formatting preservation (empty line)
+      expect(updatedContent, contains('\nenvironment:'));
+    });
+  });
+}


### PR DESCRIPTION
Replaced the `json2yaml` based version update with a regex replacement. This ensures that comments and custom formatting in `pubspec.yaml` are preserved during version updates. Added a new test case `test/pubspec_preservation_test.dart` to verify this behavior. Updated existing tests in `test/dpp_test.dart` to match the new behavior (no forced trailing newline). Ran `dart format .` on the codebase.

---
*PR created automatically by Jules for task [10023888593084046766](https://jules.google.com/task/10023888593084046766) started by @insign*