### PR TITLE
Fix rollback failure on command error

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -338,7 +338,7 @@ class DartPubPublish {
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       print('Command exited with code $exitCode');
-      exit(exitCode);
+      throw Exception('Command $command failed with exit code $exitCode');
     }
   }
 

--- a/test/rollback_runner.dart
+++ b/test/rollback_runner.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+import 'package:dpp/src/dpp.dart';
+
+void main(List<String> args) async {
+  if (args.isEmpty) {
+    print('Error: No target path provided');
+    exit(1);
+  }
+  final targetPath = args[0];
+  print('Running dpp on $targetPath');
+
+  // Create publisher instance
+  final publisher = DartPubPublish(
+    workingDir: targetPath,
+    pubGet: false, // Skip pub get to avoid network/time overhead
+    analyze: true, // This should fail due to syntax error
+    tests: false,
+    format: false,
+    fix: false,
+    git: false,
+    pubPublish: false,
+    pubspec2dart: false,
+    verbose: true
+  );
+
+  try {
+    // Attempt to publish version 1.0.1
+    // This will update pubspec.yaml to 1.0.1
+    // Then run analyze, which fails.
+    // If rollback works, pubspec.yaml should revert to 1.0.0.
+    // If rollback fails (due to exit()), pubspec.yaml remains at 1.0.1.
+    await publisher.run('1.0.1');
+  } catch (e) {
+    print('Caught exception: $e');
+    // We expect exception but also exit(code).
+    // If exit() is called inside run(), this catch block might not be reached fully or process terminates.
+  }
+}

--- a/test/rollback_test.dart
+++ b/test/rollback_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  test('verify rollback happens on failure', () async {
+    // 1. Create temp directory for the target project
+    final tempDir = await Directory.systemTemp.createTemp('dpp_repro_proj');
+    final pubspecFile = File(path.join(tempDir.path, 'pubspec.yaml'));
+
+    // We intentionally avoid dependencies to keep it self-contained and fast.
+    // The environment constraint is necessary for analyze to run.
+    await pubspecFile.writeAsString('''
+name: target_pkg
+version: 1.0.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+''');
+
+    final changeLogFile = File(path.join(tempDir.path, 'CHANGELOG.md'));
+    await changeLogFile.writeAsString('# Changelog\n');
+
+    // Create a file with syntax error to make analyze fail
+    final libDir = Directory(path.join(tempDir.path, 'lib'))..createSync();
+    File(path.join(libDir.path, 'bad.dart')).writeAsStringSync('void main() { syntax error }');
+
+    // 2. Locate the runner script
+    final runnerScriptPath = path.absolute('test/rollback_runner.dart');
+
+    print('Target project at: ${tempDir.path}');
+    print('Running dpp from: $runnerScriptPath');
+
+    // 3. Run the runner script
+    // We use `dart run` to execute the script.
+    final result = await Process.run('dart', ['run', runnerScriptPath, tempDir.path]);
+
+    print('Runner stdout: ${result.stdout}');
+    print('Runner stderr: ${result.stderr}');
+    print('Runner exit code: ${result.exitCode}');
+
+    // 4. Verify rollback
+    final currentPubspec = pubspecFile.readAsStringSync();
+
+    // We expect the version to be 1.0.0 (rolled back).
+    // If the bug exists (process exits without rollback), the version will be 1.0.1.
+    expect(currentPubspec, contains('version: 1.0.0'), reason: 'Pubspec should be rolled back to 1.0.0 but was not.');
+
+    // Cleanup
+    await tempDir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
Replaced `exit(exitCode)` with `throw Exception(...)` in `runCommand` method within `lib/src/dpp_base.dart`. This ensures that if a subprocess fails, the exception is caught by the `run` method, triggering the necessary rollback of `pubspec.yaml` and `CHANGELOG.md` before the process terminates. Added regression tests to verify this behavior.

---
*PR created automatically by Jules for task [6968209188908390701](https://jules.google.com/task/6968209188908390701) started by @insign*