### PR TITLE
Fix rollback mechanism by using exceptions instead of exit()

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -4,7 +4,7 @@ import 'package:args/args.dart';
 import 'package:dpp/src/dpp.dart';
 import 'package:dpp/pubspec.dart' as pubspec;
 
-void main(List<String> args) {
+void main(List<String> args) async {
   if (args.isNotEmpty && (args.first == '-v' || args.first == '--version')) {
     showVersion(args);
   }
@@ -83,7 +83,13 @@ void main(List<String> args) {
       analyze: argResults['analyze'],
       pubPublish: argResults['publish'],
       verbose: argResults['verbose']);
-  dpp.run(version, message: message);
+
+  try {
+    await dpp.run(version, message: message);
+  } catch (e) {
+    stderr.writeln(e);
+    exit(generalError);
+  }
 }
 
 Never showUsage(ArgParser parser) {

--- a/lib/exceptions/command_failed_exception.dart
+++ b/lib/exceptions/command_failed_exception.dart
@@ -1,0 +1,18 @@
+/// Exception thrown when a command fails with a non-zero exit code.
+class CommandFailedException implements Exception {
+  /// The command that failed.
+  final String command;
+
+  /// The arguments passed to the command.
+  final List<String> args;
+
+  /// The exit code of the command.
+  final int exitCode;
+
+  /// Creates a new instance of [CommandFailedException].
+  CommandFailedException(this.command, this.args, this.exitCode);
+
+  @override
+  String toString() =>
+      'Command "$command ${args.join(' ')}" failed with exit code $exitCode.';
+}

--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:convert';
 import 'package:all_exit_codes/all_exit_codes.dart';
+import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
 import 'package:dpp/exceptions/package_version_already_exists_exception.dart';
@@ -297,7 +298,7 @@ class DartPubPublish {
         pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
       }
 
-      exit(generalError);
+      rethrow;
     }
     if (_git) {
       final onBranch = await isBranch(_branch);
@@ -337,8 +338,7 @@ class DartPubPublish {
     });
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
-      print('Command exited with code $exitCode');
-      exit(exitCode);
+      throw CommandFailedException(command, args, exitCode);
     }
   }
 


### PR DESCRIPTION
This change fixes a critical issue where the rollback mechanism (reverting changes to `pubspec.yaml` and `CHANGELOG.md`) was bypassed when a command (like `dart test`) failed. This was because `runCommand` directly called `exit()`, terminating the process immediately. The fix involves throwing a `CommandFailedException` instead, which is caught by `DartPubPublish.run`, allowing the rollback logic to execute before rethrowing the exception to the main entry point. The main entry point now handles the exception and exits gracefully.

---
*PR created automatically by Jules for task [11196531352089467758](https://jules.google.com/task/11196531352089467758) started by @insign*