### PR TITLE
Fix subprocess output handling in runCommand

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
 import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
@@ -328,15 +327,13 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    final stdoutFuture = stdout.addStream(process.stdout);
+    final stderrFuture = stderr.addStream(process.stderr);
+
     final exitCode = await process.exitCode;
+    await Future.wait([stdoutFuture, stderrFuture]);
+
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);
     }


### PR DESCRIPTION
Improved `runCommand` in `lib/src/dpp_base.dart` to correctly handle subprocess output streaming.
Previously, `runCommand` used `print()` on chunks of output, which added unwanted newlines and could break formatting. It also decoded output as UTF-8, which might fail on non-UTF-8 output.
The new implementation pipes the raw bytes from the subprocess directly to the parent process's `stdout` and `stderr`, ensuring exact output preservation and better performance. It also awaits stream completion to ensure all output is flushed.

---
*PR created automatically by Jules for task [5375946034058682249](https://jules.google.com/task/5375946034058682249) started by @insign*