### PR TITLE
Fix runCommand output handling

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,12 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Improved `runCommand` in `lib/src/dpp_base.dart` to correctly handle subprocess output streams using `addStream` instead of `print`. This prevents extra newlines and ensures stderr is correctly separated. Also cleaned up unused imports.

---
*PR created automatically by Jules for task [16007521504589993791](https://jules.google.com/task/16007521504589993791) started by @insign*