### PR TITLE
Fix runCommand output handling to preserve newlines and stream stderr correctly

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
This change improves the `runCommand` method in `lib/src/dpp_base.dart` by using `stdout.addStream` and `stderr.addStream` instead of decoding output to UTF-8 and printing it. This ensures that the output from subprocesses is piped directly to the main process's stdout and stderr, preserving exact formatting (no extra newlines added by `print`) and avoiding potential encoding issues. It also ensures that stderr from subprocesses is correctly directed to stderr instead of stdout.

Additionally, unused imports (`dart:convert`, `dart:async`, `package:all_exit_codes/all_exit_codes.dart`) were removed.

The fix was verified with a reproduction script (`test/reproduce_issue.dart`) which confirmed that `printf` output no longer has an appended newline and `echo` output has exactly one newline, matching standard shell behavior. Existing tests passed.

---
*PR created automatically by Jules for task [13029817530445538464](https://jules.google.com/task/13029817530445538464) started by @insign*