### PR TITLE
Fix runCommand output handling to prevent extra newlines

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -328,14 +328,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Improved `runCommand` in `lib/src/dpp_base.dart` to use `stdout.addStream` and `stderr.addStream` instead of `print` with `utf8.decoder`. This fixes an issue where extra newlines were added to the output and stderr was being redirected to stdout. Verified with a reproduction script and existing tests.

---
*PR created automatically by Jules for task [14255833389240319802](https://jules.google.com/task/14255833389240319802) started by @insign*