### PR TITLE
Fix runCommand to preserve subprocess output fidelity

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -328,14 +328,12 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
This change improves the `runCommand` method in `lib/src/dpp_base.dart` to correctly handle subprocess output. Previously, `print` was used to output data chunks, which added extra newlines and merged stderr into stdout. The new implementation uses `stdout.addStream` and `stderr.addStream` to pipe the output directly, preserving the exact content and stream separation. This is critical for CLI tools that rely on precise output formatting or error redirection. Tests were created to reproduce the issue and verify the fix, and existing tests passed.

---
*PR created automatically by Jules for task [7569717428595009512](https://jules.google.com/task/7569717428595009512) started by @insign*