### PR TITLE
fix: pipe process output streams instead of decoding and printing

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -328,14 +328,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Modify `runCommand` in `lib/src/dpp_base.dart` to correctly pipe subprocess output using `stdout.addStream` and `stderr.addStream`, instead of decoding stream data and `print`ing it. Using `print` appends extra newlines to stream chunks, corrupting the formatting of command output. This change ensures precise preservation of standard output and error. Also properly waits for the streams to complete using `Future.wait`.

---
*PR created automatically by Jules for task [11335465215110900967](https://jules.google.com/task/11335465215110900967) started by @insign*