### PR TITLE
Improve subprocess output handling

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -328,14 +328,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
I've replaced `transform(utf8.decoder).listen((data) { print(data); })` with `stdout.addStream(process.stdout)` and `stderr.addStream(process.stderr)` in the `runCommand` method within `lib/src/dpp_base.dart`. 

This is an improvement because `print` appends a newline to every chunk received from the stream, which can corrupt the output formatting if a chunk does not represent a complete line. `addStream` pipes the raw bytes directly and faithfully preserves the original output format, including partial lines and binary data.

I also made sure to use `Future.wait` on both streams to await their completion before evaluating the process exit code, guaranteeing all output is flushed before continuing.

No temporary files were added or committed, and all tests are passing.

---
*PR created automatically by Jules for task [18344596382196030018](https://jules.google.com/task/18344596382196030018) started by @insign*