### PR TITLE
Fix `runCommand` output formatting

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,11 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    // Output the data as soon as it is received, preserving exact formatting
+    stdout.addStream(process.stdout);
+    stderr.addStream(process.stderr);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
This PR fixes a small bug with how the `dpp` output is streamed to the user's terminal from the processes it spawns (such as `dart test` and `git`). By using `stdout.addStream` and `stderr.addStream` instead of chunk-reading and appending newlines via `print()`, it prevents irregular line breaks and preserves exactly what the sub-process intended to show. Also cleared a couple unused imports.

---
*PR created automatically by Jules for task [17533656962041699298](https://jules.google.com/task/17533656962041699298) started by @insign*