### PR TITLE
feat: Add support for creating CHANGELOG.md if it is missing

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -162,6 +162,7 @@ class DartPubPublish {
   Future<void> run(String version,
       {String message = 'Update version number'}) async {
     String? oldChangeLogContents;
+    bool changeLogExisted = true;
     String oldPubspecContents = _pubspecFile.readAsStringSync();
     File pubspec2dartFile =
         File(path.join(_workingDir.path, 'lib', 'pubspec.dart'));
@@ -258,7 +259,12 @@ class DartPubPublish {
       if (_changelog) {
         // Add the new version number and change log message to the head of the CHANGELOG.md file
         log('Updating CHANGELOG.md...');
-        oldChangeLogContents = await _changeLogFile.readAsString();
+        if (await _changeLogFile.exists()) {
+          oldChangeLogContents = await _changeLogFile.readAsString();
+        } else {
+          oldChangeLogContents = '';
+          changeLogExisted = false;
+        }
         final newContents =
             '## v$newVersion\n- $message\n$oldChangeLogContents';
         await _changeLogFile.writeAsString(newContents);
@@ -282,7 +288,13 @@ class DartPubPublish {
       // Rollback the changes to the CHANGELOG.md file
       if (_changelog && oldChangeLogContents != null && changedChangeLog) {
         log('Rolling back changes to CHANGELOG.md...');
-        _changeLogFile.writeAsStringSync(oldChangeLogContents);
+        if (changeLogExisted) {
+          _changeLogFile.writeAsStringSync(oldChangeLogContents);
+        } else {
+          if (_changeLogFile.existsSync()) {
+            _changeLogFile.deleteSync();
+          }
+        }
       }
 
       if (_tests) {

--- a/test/changelog_missing_test.dart
+++ b/test/changelog_missing_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+import 'package:dpp/src/dpp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('missing changelog', () async {
+    final tempDir = await Directory.systemTemp.createTemp('pub_publish_test');
+    final pubspecFile = await File('${tempDir.path}/pubspec.yaml').create();
+    await pubspecFile.writeAsString('name: my_package\nversion: 1.0.0');
+
+    final publish = DartPubPublish(
+        workingDir: tempDir.path,
+        git: false,
+        analyze: false,
+        format: false,
+        fix: false,
+        tests: false,
+        pubGet: false,
+        pubspec: true,
+        pubspec2dart: false,
+        pubPublish: false);
+
+    await publish.run('2.0.0', message: 'New feature');
+
+    final changelogFile = File('${tempDir.path}/CHANGELOG.md');
+    expect(changelogFile.existsSync(), isTrue);
+    final changelogContent = await changelogFile.readAsString();
+    expect(changelogContent, '## v2.0.0\n- New feature\n');
+
+    await tempDir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
I have implemented an improvement to the `DartPubPublish` library where it handles the case where `CHANGELOG.md` is missing from the project. Before this change, the process would throw a `PathNotFoundException`. With this change, the file is created gracefully with the appropriate initial version structure. The rollback mechanism was also updated to revert the creation if something else fails during the publishing process. A new unit test has also been added.

---
*PR created automatically by Jules for task [17306995553806058191](https://jules.google.com/task/17306995553806058191) started by @insign*