### PR TITLE
Fix subprocess output handling in runCommand

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,12 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Replaced manual `print()` chunks encoded via `utf8.decoder` with direct stream piping `stdout.addStream` and `stderr.addStream`. This guarantees exact preservation of the subprocess output (avoiding injected newlines from `print()`) and `await Future.wait` ensures that stdout and stderr buffers are fully flushed before continuing. Removed unused `dart:convert` and `all_exit_codes` imports.

---
*PR created automatically by Jules for task [17777453270662168258](https://jules.google.com/task/17777453270662168258) started by @insign*