### PR TITLE
Refactor: Improve subprocess output handling in runCommand

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,12 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
The `runCommand` implementation was using `print(data)` inside a stream listener for standard output and standard error from subprocesses. Because `print` automatically appends a newline character, the raw output from executed commands was being modified with unintended newlines, making logs harder to read and slightly inaccurate.

This change switches to piping the sub-process' standard output and error directly to the Dart script's `stdout` and `stderr` using `addStream` and `Future.wait`. This ensures that output is printed exactly as it is generated by the sub-processes, without unexpected newlines or stream truncation. Additionally, this PR removes unused imports (like `package:all_exit_codes`) that were no longer needed.

---
*PR created automatically by Jules for task [742184667842762283](https://jules.google.com/task/742184667842762283) started by @insign*