### PR TITLE
Refactor subprocess stream handling in runCommand

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,12 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
+
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
I have refactored the subprocess output handling in `DartPubPublish.runCommand` to use direct stream piping (`stdout.addStream` and `stderr.addStream`) rather than relying on `print` and `utf8.decoder`. This ensures exactly identical output formatting, avoids trailing newlines inserted by `print`, and guarantees the process waits for all stdout/stderr streams to be flushed properly before returning. I've also removed some unused imports that the static analyzer was warning about.

---
*PR created automatically by Jules for task [8031833601090772189](https://jules.google.com/task/8031833601090772189) started by @insign*