### PR TITLE
Refactor runCommand process output stream handling

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
This change enhances how standard output and standard error from subprocesses are handled in the `DartPubPublish.runCommand` method.

**Changes:**
- Replaced `utf8.decoder` stream transformation and `print(data)` calls with `await Future.wait([stdout.addStream(process.stdout), stderr.addStream(process.stderr)])`.
- This ensures that:
  - Exact formatting and character sequences (including newlines) are perfectly preserved. Previously, `print()` would add a newline character per decoded text chunk, mangling the original command output.
  - The function now properly waits for the standard output and error streams to flush and complete entirely before yielding the exit code. This prevents interleaved output between consecutive commands or silent truncation.
- Fixed two unused imports in `lib/src/dpp_base.dart` detected by the dart analyzer after the `utf8.decoder` was removed.

All automated tests continue to pass.

---
*PR created automatically by Jules for task [18385993778257766121](https://jules.google.com/task/18385993778257766121) started by @insign*