### PR TITLE
Improve subprocess output formatting and reliability

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -328,14 +328,8 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait(
+        [stdout.addStream(process.stdout), stderr.addStream(process.stderr)]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
This pull request updates the `runCommand` implementation in `dpp_base.dart` to directly bind the stdout/stderr streams to the parent process using `Future.wait([stdout.addStream(...), stderr.addStream(...)])`. 

Previously, chunked output from subprocesses was decoded and passed line-by-line to `print`, resulting in incorrectly placed newlines in terminal output (since `print` automatically appends `\n` to every invocation). By streaming raw data instead, process logs maintain their original intended formatting natively, and ensures any final output chunks are flushed synchronously prior to error throwing and script exit.

---
*PR created automatically by Jules for task [8216887570229787560](https://jules.google.com/task/8216887570229787560) started by @insign*