### PR TITLE
Refactor subprocess stream handling to fix stream chunks formatting

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Refactor subprocess stream handling to fix stream chunks formatting.
Previously, chunks of output from the started process were processed using `utf8.decoder` and printed to the terminal console. Since `print()` automatically appends a newline (`\n`), chunks containing incomplete lines or formatting characters were inadvertently separated by arbitrary newlines. This could cause jumbled or spaced-out log output during `runCommand` calls, especially when processes output frequent small bursts of text. Also, the execution did not await the flushing of output streams, which could cause process exits to truncate logs.

The updated solution directly pipes the child process `stdout` and `stderr` back to the parent CLI streams utilizing `stdout.addStream` wrapped in an `await Future.wait([...])`. This properly handles binary bytes, exact formatting from the child process, and waits for streams to close. Unused `dart:convert` import was removed.

---
*PR created automatically by Jules for task [16987320124392277746](https://jules.google.com/task/16987320124392277746) started by @insign*