### PR TITLE
Improve subprocess output handling

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Replaced `.transform(utf8.decoder).listen((data) { print(data); })` with `stdout.addStream` and `stderr.addStream` in `runCommand` of `dpp_base.dart`. Using `print` appends extra newlines to every chunk of streamed output and is less suitable for preserving the exact output of commands.

Also removed the unused imports `dart:convert` and `package:all_exit_codes/all_exit_codes.dart`.

Ensured all tests (`dart test`) and static analysis (`dart analyze`) continue to pass.

---
*PR created automatically by Jules for task [15597477073740405555](https://jules.google.com/task/15597477073740405555) started by @insign*