### PR TITLE
fix: preserve exact subprocess output and error streams in runCommand

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:convert';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -328,14 +326,10 @@ class DartPubPublish {
   Future<void> runCommand(String command, List<String> args) async {
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
-    process.stdout.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
-    process.stderr.transform(utf8.decoder).listen((data) {
-      // Output the data as soon as it is received
-      print(data);
-    });
+    await Future.wait([
+      stdout.addStream(process.stdout),
+      stderr.addStream(process.stderr),
+    ]);
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw CommandFailedException(command, args, exitCode);


### PR DESCRIPTION
Update the `runCommand` function to use `stdout.addStream` and `stderr.addStream` directly, wrapped in `Future.wait`. This avoids mangling output chunks that don't end in a newline by removing `print()` and its implicit newlines.

Also cleaned up unused imports (`dart:convert` and `all_exit_codes`) that were flagged by `dart analyze`.

---
*PR created automatically by Jules for task [5533148848052045845](https://jules.google.com/task/5533148848052045845) started by @insign*