### PR TITLE
Fix version argument crash

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -58,7 +58,7 @@ void main(List<String> args) async {
   }
 
   if (argResults['version']) {
-    showVersion(parser);
+    showVersion(args);
   }
 
   if (argResults['help'] || argResults.rest.isEmpty) {
@@ -103,10 +103,10 @@ Never showUsage(ArgParser parser) {
   exit(wrongUsage);
 }
 
-Never showVersion(args) {
+Never showVersion(List<String> args) {
   final version = pubspec.version;
 
-  if (args.first == '-v') {
+  if (args.contains('-v')) {
     print(version);
   } else {
     final name = pubspec.name;

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:dpp/pubspec.dart' as pubspec;
+
+void main() {
+  group('CLI Tests', () {
+    test('version flag works with other arguments', () async {
+      final result = await Process.run('dart', ['run', 'bin/dpp.dart', '--no-git', '--version']);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), '${pubspec.name} v${pubspec.version} - ${pubspec.description.split('.').first}');
+    });
+
+    test('short version flag works with other arguments', () async {
+      final result = await Process.run('dart', ['run', 'bin/dpp.dart', '--no-git', '-v']);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), pubspec.version);
+    });
+
+    test('version flag works as first argument', () async {
+      final result = await Process.run('dart', ['run', 'bin/dpp.dart', '--version']);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), '${pubspec.name} v${pubspec.version} - ${pubspec.description.split('.').first}');
+    });
+
+    test('short version flag works as first argument', () async {
+      final result = await Process.run('dart', ['run', 'bin/dpp.dart', '-v']);
+
+      expect(result.exitCode, 0);
+      expect(result.stdout.toString().trim(), pubspec.version);
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes a bug in `bin/dpp.dart` where `showVersion(parser)` was mistakenly called instead of `showVersion(args)`, causing a crash (`NoSuchMethodError: Class 'ArgParser' has no instance getter 'first'`). It also improves `showVersion(args)` to properly support any argument order by replacing `args.first == '-v'` with `args.contains('-v')`. A new test `test/cli_test.dart` was added to verify the `dart run bin/dpp.dart --no-git --version` command works properly under different argument setups without crashing.

---
*PR created automatically by Jules for task [8695971233959799466](https://jules.google.com/task/8695971233959799466) started by @insign*