### PR TITLE
feat: added dry-run flag

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -47,6 +47,10 @@ void main(List<String> args) async {
         abbr: 'v',
         negatable: false,
         help: 'Show the version of ${pubspec.name}.')
+    ..addFlag('dry-run',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Run the script without making any changes.')
     ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage help.');
 
   ArgResults argResults;
@@ -82,7 +86,8 @@ void main(List<String> args) async {
       format: argResults['format'],
       analyze: argResults['analyze'],
       pubPublish: argResults['publish'],
-      verbose: argResults['verbose']);
+      verbose: argResults['verbose'],
+      dryRun: argResults['dry-run']);
 
   try {
     await dpp.run(version, message: message);

--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -61,6 +60,9 @@ class DartPubPublish {
   /// A flag indicating whether to print log messages to the console.
   final bool _verbose;
 
+  /// A flag indicating whether to perform a dry run.
+  final bool _dryRun;
+
   /// Creates a new instance of [DartPubPublish].
   ///
   /// [pubspecFile] and [changeLogFile] are the file paths to the pubspec and
@@ -105,7 +107,8 @@ class DartPubPublish {
       format = true,
       analyze = true,
       pubPublish = true,
-      verbose = true})
+      verbose = true,
+      dryRun = false})
       : _workingDir =
             workingDir != null ? Directory(workingDir) : Directory.current,
         _pubspecFile = pubspecFile != null
@@ -128,7 +131,8 @@ class DartPubPublish {
         _format = format,
         _analyze = analyze,
         _publish = pubPublish,
-        _verbose = verbose {
+        _verbose = verbose,
+        _dryRun = dryRun {
     if (!_pubspecFile.existsSync()) {
       throw PubspecNotFound(_pubspecFile.path);
     }
@@ -212,9 +216,13 @@ class DartPubPublish {
         'version: $newVersion',
       );
 
-      _pubspecFile.writeAsStringSync(updatedPubspecContents);
-      log('Updated version in pubspec.yaml from $oldVersion to $newVersion');
-      changedPubspec = true;
+      if (_dryRun) {
+        log('[DRY-RUN] Would update version in pubspec.yaml to $newVersion');
+      } else {
+        _pubspecFile.writeAsStringSync(updatedPubspecContents);
+        log('Updated version in pubspec.yaml from $oldVersion to $newVersion');
+        changedPubspec = true;
+      }
     }
     try {
       if (_get) {
@@ -240,9 +248,13 @@ class DartPubPublish {
           log('No lib folder found, ignoring pubspec2dart option', error: true);
         } else {
           final dest = path.join(_workingDir.path, 'lib', 'pubspec.dart');
-          final y2d = Yaml2Dart(_pubspecFile.path, dest);
-          await y2d.convert();
-          changedPubspec2dart = true;
+          if (_dryRun) {
+            log('[DRY-RUN] Would create pubspec.dart in $dest');
+          } else {
+            final y2d = Yaml2Dart(_pubspecFile.path, dest);
+            await y2d.convert();
+            changedPubspec2dart = true;
+          }
         }
       }
 
@@ -266,8 +278,12 @@ class DartPubPublish {
         }
         final newContents =
             '## v$newVersion\n- $message\n$oldChangeLogContents';
-        await _changeLogFile.writeAsString(newContents);
-        changedChangeLog = true;
+        if (_dryRun) {
+          log('[DRY-RUN] Would update CHANGELOG.md with:\n## v$newVersion\n- $message');
+        } else {
+          await _changeLogFile.writeAsString(newContents);
+          changedChangeLog = true;
+        }
       }
 
       if (_publish) {
@@ -335,6 +351,10 @@ class DartPubPublish {
   /// If the process exits with a non-zero exit code, a message indicating the exit code is printed to the console and
   /// the program is terminated with that exit code.
   Future<void> runCommand(String command, List<String> args) async {
+    if (_dryRun) {
+      log('[DRY-RUN] Would run: $command ${args.join(' ')}');
+      return;
+    }
     final process =
         await Process.start(command, args, workingDirectory: _workingDir.path);
     await Future.wait([

--- a/test/dry_run_test.dart
+++ b/test/dry_run_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'package:dpp/src/dpp_base.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DartPubPublish - Dry Run', () {
+    late Directory tempDir;
+    late File pubspecFile;
+    late File changeLogFile;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('pub_publish_test_dry_run');
+      pubspecFile = File('${tempDir.path}/pubspec.yaml');
+      await pubspecFile.writeAsString('name: my_package\nversion: 1.0.0');
+      changeLogFile = File('${tempDir.path}/CHANGELOG.md');
+      await changeLogFile.writeAsString('## v1.0.0\n- Initial release\n');
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('dry run does not modify files or run commands', () async {
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: true,
+          analyze: true,
+          format: true,
+          fix: true,
+          tests: true,
+          pubGet: true,
+          pubspec: true,
+          pubspec2dart: true,
+          pubPublish: true,
+          verbose: true,
+          dryRun: true);
+
+      await publish.run('2.0.0', message: 'New feature');
+
+      // Check pubspec.yaml hasn't changed
+      final updatedPubspec = pubspecFile.readAsStringSync();
+      expect(updatedPubspec, 'name: my_package\nversion: 1.0.0');
+
+      // Check CHANGELOG.md hasn't changed
+      final updatedChangeLog = changeLogFile.readAsStringSync();
+      expect(updatedChangeLog, '## v1.0.0\n- Initial release\n');
+
+      // Check pubspec.dart hasn't been created
+      final pubspecDartFile = File('${tempDir.path}/lib/pubspec.dart');
+      expect(pubspecDartFile.existsSync(), false);
+    });
+  });
+}


### PR DESCRIPTION
Added a `--dry-run` flag to the dpp CLI to allow users to verify the sequence of actions that will be performed without actually modifying any files or running any external commands.

*   Added `--dry-run` flag to the `ArgParser` in `bin/dpp.dart`.
*   Passed `dryRun` value into the `DartPubPublish` constructor.
*   Updated `DartPubPublish` (`lib/src/dpp_base.dart`) to short-circuit file modifications and system commands when `_dryRun` is true, replacing them with descriptive logs (`[DRY-RUN]`).
*   Created `test/dry_run_test.dart` to verify that `dryRun: true` does not modify `pubspec.yaml`, `CHANGELOG.md`, or create `pubspec.dart`.
*   Cleaned up an unused import in `dpp_base.dart`.

---
*PR created automatically by Jules for task [14107840336453070647](https://jules.google.com/task/14107840336453070647) started by @insign*