### PR TITLE
Fix version flag crash and remove unused import

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -6,7 +6,7 @@ import 'package:dpp/pubspec.dart' as pubspec;
 
 void main(List<String> args) async {
   if (args.isNotEmpty && (args.first == '-v' || args.first == '--version')) {
-    showVersion(args);
+    showVersion(short: args.first == '-v');
   }
 
   final parser = ArgParser()
@@ -58,7 +58,7 @@ void main(List<String> args) async {
   }
 
   if (argResults['version']) {
-    showVersion(parser);
+    showVersion(short: false);
   }
 
   if (argResults['help'] || argResults.rest.isEmpty) {
@@ -103,10 +103,10 @@ Never showUsage(ArgParser parser) {
   exit(wrongUsage);
 }
 
-Never showVersion(args) {
+Never showVersion({bool short = false}) {
   final version = pubspec.version;
 
-  if (args.first == '-v') {
+  if (short) {
     print(version);
   } else {
     final name = pubspec.name;

--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';


### PR DESCRIPTION
I've made an improvement to the system by fixing a crash when using the `--version` flag. In `bin/dpp.dart`, `showVersion` was being called with `parser` (`ArgParser`), but the method assumed it received a list, which caused a `NoSuchMethodError` crash when the user passed the `--version` option with other arguments. I updated the code to use strongly typed named arguments (`showVersion({bool short = false})`) to fix this.
I also removed an unused import in `lib/src/dpp_base.dart` to fix static analysis warnings.

Tests and static analysis have been passed.

---
*PR created automatically by Jules for task [12910454338500061091](https://jules.google.com/task/12910454338500061091) started by @insign*