### PR TITLE
Fix pubspec2dart rollback logic and unused import

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -300,11 +299,13 @@ class DartPubPublish {
       }
 
       // Rollback the changes to the pubspec2dart file
-      if (_pubspec2dart &&
-          oldPubspec2dartContents != null &&
-          changedPubspec2dart) {
+      if (_pubspec2dart && changedPubspec2dart) {
         log('Rolling back changes to pubspec2dart...');
-        pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+        if (oldPubspec2dartContents != null) {
+          pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+        } else if (pubspec2dartFile.existsSync()) {
+          pubspec2dartFile.deleteSync();
+        }
       }
 
       rethrow;


### PR DESCRIPTION
1. Fixed a bug in `lib/src/dpp_base.dart` where `pubspec2dart` would not be properly deleted during rollback if it did not exist prior to the script execution.
2. Cleaned up an unused import of `package:all_exit_codes/all_exit_codes.dart` in `lib/src/dpp_base.dart`.
3. Validated changes with test suites and statically with `dart analyze`.

---
*PR created automatically by Jules for task [7106444573174614308](https://jules.google.com/task/7106444573174614308) started by @insign*