### PR TITLE
fix: improve rollback logic on git and test failures

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -174,7 +174,8 @@ class DartPubPublish {
     Version newVersion;
     bool changedChangeLog = false,
         changedPubspec = false,
-        changedPubspec2dart = false;
+        changedPubspec2dart = false,
+        packagePublished = false;
 
     try {
       newVersion = Version.parse(version);
@@ -274,55 +275,70 @@ class DartPubPublish {
         // Publish the package to pub.dev
         log('Publishing package to pub.dev...');
         await runCommand('dart', ['pub', 'publish', '--force']);
+        packagePublished = true;
+      }
+
+      if (_git) {
+        final onBranch = await isBranch(_branch);
+        if (!_anyBranch && !onBranch) {
+          log('Not on $_branch branch, skipping git commands', error: true);
+        } else {
+          // Commit and push the changes and tag the new version
+          log('Committing and pushing changes...');
+          await runCommand('git', ['add', '.']);
+          await runCommand('git', ['commit', '-m', message]);
+          log('Tagging new version...');
+          await runCommand('git', ['tag', 'v$newVersion']);
+          await runCommand('git', ['push']);
+          await runCommand('git', ['push', '--tags']);
+        }
       }
     } on Exception catch (e) {
-      // Rollback the changes to the pubspec.yaml file
       log(e.toString(), error: true);
 
-      if (_pubspec && changedPubspec) {
-        log('Rolling back changes to pubspec.yaml...');
-        _pubspecFile.writeAsStringSync(oldPubspecContents);
-      }
+      if (packagePublished) {
+        log('Package was successfully published to pub.dev, but a subsequent command (like git) failed.',
+            error: true);
+        log('Skipping rollback of local files to keep them in sync with the published version.',
+            error: true);
+      } else {
+        // Rollback the changes to the pubspec.yaml file
+        if (_pubspec && changedPubspec) {
+          log('Rolling back changes to pubspec.yaml...');
+          _pubspecFile.writeAsStringSync(oldPubspecContents);
+        }
 
-      // Rollback the changes to the CHANGELOG.md file
-      if (_changelog && oldChangeLogContents != null && changedChangeLog) {
-        log('Rolling back changes to CHANGELOG.md...');
-        if (changeLogExisted) {
-          _changeLogFile.writeAsStringSync(oldChangeLogContents);
-        } else if (_changeLogFile.existsSync()) {
-          _changeLogFile.deleteSync();
+        // Rollback the changes to the CHANGELOG.md file
+        if (_changelog && oldChangeLogContents != null && changedChangeLog) {
+          log('Rolling back changes to CHANGELOG.md...');
+          if (changeLogExisted) {
+            _changeLogFile.writeAsStringSync(oldChangeLogContents);
+          } else if (_changeLogFile.existsSync()) {
+            _changeLogFile.deleteSync();
+          }
+        }
+
+        if (_tests) {
+          log('Running last dart tests...');
+          try {
+            await runCommand('dart', ['test', '--tags', 'dpp']);
+          } on CommandFailedException catch (_) {
+            // Ignore command failures during rollback to avoid masking the original exception
+          }
+        }
+
+        // Rollback the changes to the pubspec2dart file
+        if (_pubspec2dart && changedPubspec2dart) {
+          log('Rolling back changes to pubspec2dart...');
+          if (oldPubspec2dartContents != null) {
+            pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+          } else if (pubspec2dartFile.existsSync()) {
+            pubspec2dartFile.deleteSync();
+          }
         }
       }
 
-      if (_tests) {
-        log('Running last dart tests...');
-        await runCommand('dart', ['test', '--tags', 'dpp']);
-      }
-
-      // Rollback the changes to the pubspec2dart file
-      if (_pubspec2dart &&
-          oldPubspec2dartContents != null &&
-          changedPubspec2dart) {
-        log('Rolling back changes to pubspec2dart...');
-        pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
-      }
-
       rethrow;
-    }
-    if (_git) {
-      final onBranch = await isBranch(_branch);
-      if (!_anyBranch && !onBranch) {
-        log('Not on $_branch branch, skipping git commands', error: true);
-      } else {
-        // Commit and push the changes and tag the new version
-        log('Committing and pushing changes...');
-        await runCommand('git', ['add', '.']);
-        await runCommand('git', ['commit', '-m', message]);
-        log('Tagging new version...');
-        await runCommand('git', ['tag', 'v$newVersion']);
-        await runCommand('git', ['push']);
-        await runCommand('git', ['push', '--tags']);
-      }
     }
   }
 

--- a/test/dpp_test.dart
+++ b/test/dpp_test.dart
@@ -45,6 +45,38 @@ void main() {
       expect(updatedChangeLog, expectedChangeLog);
     });
 
+    test('rollback on git failure', () async {
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: true,
+          anyBranch: true,
+          analyze: false,
+          format: false,
+          fix: false,
+          tests: false,
+          pubGet: false,
+          pubspec: true,
+          pubspec2dart: false,
+          pubPublish: false);
+
+      // Since it's not a git repository, the git commands will fail
+      try {
+        await publish.run('2.0.0', message: 'New feature');
+        fail('Should have thrown an exception');
+      } catch (e) {
+        // Expected
+      }
+
+      final updatedPubspec = pubspecFile.readAsStringSync();
+      final expectedPubspec = 'name: my_package\nversion: 1.0.0';
+      expect(updatedPubspec, expectedPubspec);
+
+      final updatedChangeLog = changeLogFile.readAsStringSync();
+      expect(updatedChangeLog, isEmpty);
+    });
+
     test('using alias - change changelog and pubspec', () async {
       final publish = DartPubPublish(
           pubspecFile: pubspecFile.path,


### PR DESCRIPTION
This PR introduces an important improvement to the `DartPubPublish` rollback mechanism by addressing edge cases related to Git and test failures:

1. **Git operations now trigger rollback (conditionally)**: Moving git operations into the main `try/catch` block ensures that if a command like `git add` or `git tag` fails, the local `pubspec.yaml` and `CHANGELOG.md` edits are reverted. 
2. **Prevent Desyncs after Publish**: If a package successfully gets published to pub.dev (`packagePublished == true`) but a subsequent Git operation fails, the system now intelligently skips the rollback. This prevents local files from reverting to an older version while the remote package manager has the newer version.
3. **Robust Test Rollback**: Swallowing `CommandFailedException` during the rollback tests ensures the original exception that caused the rollback isn't masked by failing rollback tests.
4. **pubspec.dart Cleanup**: Fixed the rollback mechanism for `pubspec.dart` to actually delete the file if it wasn't present originally.
5. **New Unit Tests**: Added a test case in `test/dpp_test.dart` asserting that a failure in a git operation correctly triggers the rollback logic.

---
*PR created automatically by Jules for task [4820252147477872189](https://jules.google.com/task/4820252147477872189) started by @insign*