### PR TITLE
Fix rollback logic in dpp

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -296,19 +295,27 @@ class DartPubPublish {
 
       if (_tests) {
         log('Running last dart tests...');
-        await runCommand('dart', ['test', '--tags', 'dpp']);
+        try {
+          await runCommand('dart', ['test', '--tags', 'dpp']);
+        } on CommandFailedException {
+          // Ignore command failures during rollback test execution
+          log('Tests failed during rollback, ignoring...', error: true);
+        }
       }
 
       // Rollback the changes to the pubspec2dart file
-      if (_pubspec2dart &&
-          oldPubspec2dartContents != null &&
-          changedPubspec2dart) {
+      if (_pubspec2dart && changedPubspec2dart) {
         log('Rolling back changes to pubspec2dart...');
-        pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+        if (oldPubspec2dartContents != null) {
+          pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+        } else if (pubspec2dartFile.existsSync()) {
+          pubspec2dartFile.deleteSync();
+        }
       }
 
       rethrow;
     }
+
     if (_git) {
       final onBranch = await isBranch(_branch);
       if (!_anyBranch && !onBranch) {

--- a/test/rollback_test.dart
+++ b/test/rollback_test.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+import 'package:dpp/src/dpp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Rollback behavior', () {
+    late Directory tempDir;
+    late File pubspecFile;
+    late File changeLogFile;
+    late Directory libDir;
+    late File dartFile;
+
+    setUp(() async {
+      tempDir =
+          await Directory.systemTemp.createTemp('pub_publish_test_rollback');
+
+      pubspecFile = await File('${tempDir.path}/pubspec.yaml').create();
+      await pubspecFile.writeAsString(
+          'name: my_package\nversion: 1.0.0\nenvironment:\n  sdk: ">=3.0.0 <4.0.0"\n');
+
+      changeLogFile = await File('${tempDir.path}/CHANGELOG.md').create();
+      await changeLogFile.writeAsString('## v1.0.0\n- Initial release\n');
+
+      libDir = await Directory('${tempDir.path}/lib').create();
+
+      // We create a broken dart file so that dart format or analyze will fail, triggering a rollback
+      dartFile = await File('${libDir.path}/broken.dart').create();
+      await dartFile.writeAsString(
+          'void main() { print("hello" }'); // Missing closing parenthesis
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('rolls back pubspec, changelog and deletes pubspec.dart on failure',
+        () async {
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: false,
+          analyze: true, // Analyze will fail on the broken dart file
+          format: false,
+          fix: false,
+          tests: false,
+          pubGet: false,
+          pubspec: true,
+          pubspec2dart: true,
+          pubPublish: false,
+          verbose: false);
+
+      try {
+        await publish.run('2.0.0', message: 'New feature');
+        fail('Should have thrown an exception');
+      } catch (e) {
+        // Expected an exception
+      }
+
+      final updatedPubspec = pubspecFile.readAsStringSync();
+      final expectedPubspec =
+          'name: my_package\nversion: 1.0.0\nenvironment:\n  sdk: ">=3.0.0 <4.0.0"\n';
+      expect(updatedPubspec, expectedPubspec,
+          reason: 'Pubspec should be rolled back');
+
+      final updatedChangeLog = changeLogFile.readAsStringSync();
+      final expectedChangeLog = '## v1.0.0\n- Initial release\n';
+      expect(updatedChangeLog, expectedChangeLog,
+          reason: 'Changelog should be rolled back');
+
+      final pubspecDartFile = File('${libDir.path}/pubspec.dart');
+      expect(pubspecDartFile.existsSync(), isFalse,
+          reason: 'pubspec.dart should have been deleted');
+    });
+  });
+}


### PR DESCRIPTION
Improves the rollback logic to handle the newly generated `pubspec.dart` file properly. Wrapped `dart test` rollback call in a `try-catch` to avoid failing the rollback mechanism itself due to test failures. I also created `test/rollback_test.dart` and added integration tests for testing that rollback logic correctly reverts `pubspec.yaml`, `CHANGELOG.md`, and removes `pubspec.dart` on failure.

---
*PR created automatically by Jules for task [9676369480066224420](https://jules.google.com/task/9676369480066224420) started by @insign*