### PR TITLE
Fix rollback interruption on test failure

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:all_exit_codes/all_exit_codes.dart';
 import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
@@ -296,7 +295,11 @@ class DartPubPublish {
 
       if (_tests) {
         log('Running last dart tests...');
-        await runCommand('dart', ['test', '--tags', 'dpp']);
+        try {
+          await runCommand('dart', ['test', '--tags', 'dpp']);
+        } on CommandFailedException {
+          // Ignore command failure on rollback
+        }
       }
 
       // Rollback the changes to the pubspec2dart file


### PR DESCRIPTION
Wrapped the `dart test` rollback command in `lib/src/dpp_base.dart` with a `try-catch` block to ensure that if tests fail during the rollback phase, the resulting `CommandFailedException` is ignored. This guarantees that subsequent rollback operations, like restoring `pubspec.dart`, are not skipped.
Also removed an unused import.

---
*PR created automatically by Jules for task [4872452585763351097](https://jules.google.com/task/4872452585763351097) started by @insign*