### PR TITLE
Fix rollback logic to correctly delete newly created pubspec.dart

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -165,8 +165,9 @@ class DartPubPublish {
     String oldPubspecContents = _pubspecFile.readAsStringSync();
     File pubspec2dartFile =
         File(path.join(_workingDir.path, 'lib', 'pubspec.dart'));
+    bool pubspec2dartExisted = pubspec2dartFile.existsSync();
     String? oldPubspec2dartContents =
-        _pubspec2dart && pubspec2dartFile.existsSync()
+        _pubspec2dart && pubspec2dartExisted
             ? pubspec2dartFile.readAsStringSync()
             : null;
     final yaml = loadYaml(oldPubspecContents);
@@ -304,11 +305,13 @@ class DartPubPublish {
       }
 
       // Rollback the changes to the pubspec2dart file
-      if (_pubspec2dart &&
-          oldPubspec2dartContents != null &&
-          changedPubspec2dart) {
+      if (_pubspec2dart && changedPubspec2dart) {
         log('Rolling back changes to pubspec2dart...');
-        pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents);
+        if (pubspec2dartExisted) {
+          pubspec2dartFile.writeAsStringSync(oldPubspec2dartContents!);
+        } else if (pubspec2dartFile.existsSync()) {
+          pubspec2dartFile.deleteSync();
+        }
       }
 
       rethrow;

--- a/test/rollback_test.dart
+++ b/test/rollback_test.dart
@@ -87,4 +87,63 @@ void main() {
       tempDir.deleteSync(recursive: true);
     }
   });
+
+  test('Rollback deletes pubspec.dart if it was newly created', () async {
+    final tempDir = Directory.systemTemp.createTempSync('dpp_rollback_test2_');
+
+    try {
+      await Process.run('git', ['init'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.email', 'test@example.com'],
+          workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.name', 'Test User'],
+          workingDirectory: tempDir.path);
+
+      final pubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
+      await pubspecFile.writeAsString('''
+name: test_pkg
+version: 1.0.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+''');
+
+      final libDir = Directory(p.join(tempDir.path, 'lib'))..createSync();
+      final pubspecDartFile = File(p.join(libDir.path, 'pubspec.dart'));
+
+      // 4. Create a failing test in test/ folder to trigger rollback after pubspec.dart is created
+      // In normal flow, tests run BEFORE pubspec.dart is created.
+      // So we must bypass tests or make publish fail to test rollback AFTER pubspec.dart is created.
+      // Easiest is to let pub publish fail because there's no publish configuration/credentials.
+
+      await Process.run('git', ['add', '.'], workingDirectory: tempDir.path);
+      await Process.run('git', ['commit', '-m', 'Initial commit'],
+          workingDirectory: tempDir.path);
+
+      final dppPath = p.join(Directory.current.path, 'bin', 'dpp.dart');
+      final result = await Process.run(
+        'dart',
+        [
+          dppPath,
+          '1.0.1',
+          '--pubspec',
+          '--pubspec2dart',
+          '--publish', // this will fail without proper setup
+          '--no-git',
+          '--no-tests', // skip tests so it reaches publish step
+        ],
+        workingDirectory: tempDir.path,
+      );
+
+      // Verify command failed
+      expect(result.exitCode, isNot(0));
+
+      // Verify rollback deleted pubspec.dart
+      expect(pubspecDartFile.existsSync(), isFalse);
+
+      // Check for rollback log output
+      expect(result.stdout.toString(), contains('Rolling back changes to pubspec2dart...'));
+
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
Fixes a bug where `pubspec.dart` is left behind during a failed publish if it was newly created by the current run.
This aggregates real value because the core promise of the CLI is robust rollback behavior upon failure, ensuring a clean state, and previously the `pubspec.dart` was leaking.

---
*PR created automatically by Jules for task [9804126193234086775](https://jules.google.com/task/9804126193234086775) started by @insign*