### PR TITLE
Fix: Fail fast when on the wrong branch to avoid dirtying the repository

### DIFF
--- a/lib/exceptions/wrong_git_branch_exception.dart
+++ b/lib/exceptions/wrong_git_branch_exception.dart
@@ -1,0 +1,11 @@
+class WrongGitBranchException implements Exception {
+  final String? expectedBranch;
+
+  WrongGitBranchException(this.expectedBranch);
+
+  @override
+  String toString() {
+    final branchStr = expectedBranch ?? 'main or master';
+    return 'WrongGitBranchException: Not on $branchStr branch. Checkout $branchStr or use --any-branch to allow publishing from current branch.';
+  }
+}

--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -4,6 +4,7 @@ import 'package:dpp/exceptions/command_failed_exception.dart';
 import 'package:dpp/exceptions/package_version_lower_exception.dart';
 import 'package:dpp/exceptions/pubspec_not_found.dart';
 import 'package:dpp/exceptions/package_version_already_exists_exception.dart';
+import 'package:dpp/exceptions/wrong_git_branch_exception.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
@@ -197,6 +198,13 @@ class DartPubPublish {
       throw PackageVersionLowerException(newVersion, oldVersion);
     }
 
+    if (_git && !_anyBranch) {
+      final onBranch = await isBranch(_branch);
+      if (!onBranch) {
+        throw WrongGitBranchException(_branch);
+      }
+    }
+
     log('Publishing package to pub.dev...');
     log('Old version: $oldVersion');
     log('New version: $newVersion');
@@ -314,19 +322,14 @@ class DartPubPublish {
       rethrow;
     }
     if (_git) {
-      final onBranch = await isBranch(_branch);
-      if (!_anyBranch && !onBranch) {
-        log('Not on $_branch branch, skipping git commands', error: true);
-      } else {
-        // Commit and push the changes and tag the new version
-        log('Committing and pushing changes...');
-        await runCommand('git', ['add', '.']);
-        await runCommand('git', ['commit', '-m', message]);
-        log('Tagging new version...');
-        await runCommand('git', ['tag', 'v$newVersion']);
-        await runCommand('git', ['push']);
-        await runCommand('git', ['push', '--tags']);
-      }
+      // Commit and push the changes and tag the new version
+      log('Committing and pushing changes...');
+      await runCommand('git', ['add', '.']);
+      await runCommand('git', ['commit', '-m', message]);
+      log('Tagging new version...');
+      await runCommand('git', ['tag', 'v$newVersion']);
+      await runCommand('git', ['push']);
+      await runCommand('git', ['push', '--tags']);
     }
   }
 

--- a/test/branch_check_test.dart
+++ b/test/branch_check_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('fails fast if branch check fails', () async {
+    final tempDir = Directory.systemTemp.createTempSync('fail_fast_test_');
+
+    try {
+      await Process.run('git', ['init', '-b', 'main'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.email', 'test@example.com'], workingDirectory: tempDir.path);
+      await Process.run('git', ['config', 'user.name', 'Test User'], workingDirectory: tempDir.path);
+
+      final pubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
+      await pubspecFile.writeAsString('''
+name: test_pkg
+version: 1.0.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+''');
+
+      await Process.run('git', ['add', '.'], workingDirectory: tempDir.path);
+      await Process.run('git', ['commit', '-m', 'Initial commit'], workingDirectory: tempDir.path);
+      await Process.run('git', ['checkout', '-b', 'feature-branch'], workingDirectory: tempDir.path);
+
+      final dppPath = p.join(Directory.current.path, 'bin', 'dpp.dart');
+      final result = await Process.run(
+        'dart',
+        [
+          dppPath,
+          '1.0.1',
+          '--no-publish',
+          '--git',
+          '--no-tests',
+          '--no-fix',
+          '--no-format',
+          '--no-analyze'
+        ],
+        workingDirectory: tempDir.path,
+      );
+
+      print('STDOUT: ${result.stdout}');
+      print('STDERR: ${result.stderr}');
+
+      expect(result.exitCode, isNot(0));
+      expect(result.stderr.toString(), contains('WrongGitBranchException'));
+
+      final updatedPubspec = await pubspecFile.readAsString();
+      expect(updatedPubspec, contains('version: 1.0.0'));
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
Fix: Fail fast when on the wrong branch to avoid dirtying the repository

This PR improves the reliability and UX of the tool by moving the git branch verification to the very beginning of the publishing process. Previously, the tool would update files (like pubspec.yaml and CHANGELOG.md), run tests, format code, and only at the very end realize it was on the wrong branch and skip git commands. This resulted in an inconsistent, dirty local repository that users had to manually clean up. By throwing a \`WrongGitBranchException\` early, we ensure the execution safely aborts before any irreversible changes are made.

---
*PR created automatically by Jules for task [12418666079340055524](https://jules.google.com/task/12418666079340055524) started by @insign*