### PR TITLE
Fix execution order: run code generation and format before tests and analysis

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -232,15 +232,6 @@ class DartPubPublish {
         await runCommand('dart', ['pub', 'get']);
       }
 
-      if (_analyze) {
-        log('Running dart analyze...');
-        await runCommand('dart', ['analyze']);
-      }
-      if (_tests) {
-        log('Running dart tests...');
-        await runCommand('dart', ['test', '--exclude-tags', 'dpp']);
-      }
-
       if (_pubspec2dart) {
         // Create the pubspec.dart file
         log('Creating pubspec.dart... inside lib folder');
@@ -262,6 +253,15 @@ class DartPubPublish {
       if (_format) {
         log('Running dart format...');
         await runCommand('dart', ['format', '.', '--line-length', '120']);
+      }
+
+      if (_analyze) {
+        log('Running dart analyze...');
+        await runCommand('dart', ['analyze']);
+      }
+      if (_tests) {
+        log('Running dart tests...');
+        await runCommand('dart', ['test', '--exclude-tags', 'dpp']);
       }
 
       if (_changelog) {

--- a/test/rollback_test.dart
+++ b/test/rollback_test.dart
@@ -79,8 +79,8 @@ void main() {
       expect(result.stdout.toString(), contains('Rolling back changes to pubspec.yaml...'));
       expect(result.stdout.toString(), contains('Running last dart tests...'));
       expect(result.stdout.toString(), contains('Tests failed during rollback')); // it logs on stdout with [ERROR] or stderr? Let's check stdout since log() prints.
-      // pubspec2dart was never created because tests failed before it!
-      // expect(result.stdout.toString(), contains('Rolling back changes to pubspec2dart...'));
+      // pubspec2dart was created before tests, so it should be rolled back!
+      expect(result.stdout.toString(), contains('Rolling back changes to pubspec2dart...'));
 
     } finally {
       // Cleanup
@@ -110,9 +110,8 @@ environment:
       final pubspecDartFile = File(p.join(libDir.path, 'pubspec.dart'));
 
       // 4. Create a failing test in test/ folder to trigger rollback after pubspec.dart is created
-      // In normal flow, tests run BEFORE pubspec.dart is created.
-      // So we must bypass tests or make publish fail to test rollback AFTER pubspec.dart is created.
-      // Easiest is to let pub publish fail because there's no publish configuration/credentials.
+      // Since pubspec.dart is created BEFORE tests, any test failure will trigger rollback
+      // of both pubspec.yaml and pubspec.dart.
 
       await Process.run('git', ['add', '.'], workingDirectory: tempDir.path);
       await Process.run('git', ['commit', '-m', 'Initial commit'],


### PR DESCRIPTION
Reorders the execution pipeline in `DartPubPublish.run` so that code generation (`pubspec2dart`) and formatting/fixes run *before* `dart analyze` and `dart test`. 

This fixes a critical bug where tests verifying package versions via the auto-generated `pubspec.dart` file would always fail, as they were running against the pre-generation codebase.

I also updated `test/rollback_test.dart` to assert that the `pubspec.dart` gets properly rolled back upon test failure, which now naturally occurs because it is generated before tests run.

---
*PR created automatically by Jules for task [8036644405147490943](https://jules.google.com/task/8036644405147490943) started by @insign*