### PR TITLE
fix: resolve crash when using --version flag outside the first position

### DIFF
--- a/bin/dpp.dart
+++ b/bin/dpp.dart
@@ -6,7 +6,7 @@ import 'package:dpp/pubspec.dart' as pubspec;
 
 void main(List<String> args) async {
   if (args.isNotEmpty && (args.first == '-v' || args.first == '--version')) {
-    showVersion(args);
+    showVersion(args.first == '-v');
   }
 
   final parser = ArgParser()
@@ -58,7 +58,7 @@ void main(List<String> args) async {
   }
 
   if (argResults['version']) {
-    showVersion(parser);
+    showVersion(args.contains('-v'));
   }
 
   if (argResults['help'] || argResults.rest.isEmpty) {
@@ -103,10 +103,10 @@ Never showUsage(ArgParser parser) {
   exit(wrongUsage);
 }
 
-Never showVersion(args) {
+Never showVersion(bool isShort) {
   final version = pubspec.version;
 
-  if (args.first == '-v') {
+  if (isShort) {
     print(version);
   } else {
     final name = pubspec.name;

--- a/test/cli_version_test.dart
+++ b/test/cli_version_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  group('CLI Version Command', () {
+    final dppBin = '${Directory.current.path}/bin/dpp.dart';
+
+    test('returns only version number with -v flag', () async {
+      final result = await Process.run('dart', ['run', dppBin, '-v']);
+      expect(result.exitCode, equals(0));
+      // Deve conter apenas versão do package e nada mais (ex: 2.7.3)
+      expect(result.stdout.toString().trim(), matches(RegExp(r'^\d+\.\d+\.\d+$')));
+    });
+
+    test('returns only version number with -v even with other flags', () async {
+      final result = await Process.run('dart', ['run', dppBin, '--no-git', '-v']);
+      expect(result.exitCode, equals(0));
+      expect(result.stdout.toString().trim(), matches(RegExp(r'^\d+\.\d+\.\d+$')));
+    });
+
+    test('returns full version text with --version flag', () async {
+      final result = await Process.run('dart', ['run', dppBin, '--version']);
+      expect(result.exitCode, equals(0));
+      expect(result.stdout.toString().trim(), startsWith('dpp v'));
+      expect(result.stdout.toString().trim(), contains('A better dart'));
+    });
+
+    test('returns full version text with --version even with other flags', () async {
+      final result = await Process.run('dart', ['run', dppBin, '--no-git', '--version']);
+      expect(result.exitCode, equals(0));
+      expect(result.stdout.toString().trim(), startsWith('dpp v'));
+      expect(result.stdout.toString().trim(), contains('A better dart'));
+    });
+  });
+}


### PR DESCRIPTION
Resolve crash no CLI ao chamar a flag `--version` fora da primeira posição.

**Qual melhoria foi escolhida?**
Foi corrigido um bug grave na UX/Confiabilidade do CLI: o comando crasheava (`NoSuchMethodError`) ao utilizar a flag `--version` se ela não fosse estritamente o primeiro argumento passado (por exemplo: `dpp --no-git --version`), e também lidava incorretamente com o ArgParser.

**Por que agrega valor real ao projeto?**
Sendo `dpp` uma ferramenta de linha de comando CLI, é imperativo que suas flags, especialmente a flag de versão (`--version` e `-v`), não gerem falhas críticas no aplicativo baseadas puramente na posição ou misturadas com outras flags. A correção impede a interrupção abrupta do fluxo do usuário e assegura que os scripts e humanos consigam ler a versão independente de como foi inserida.

**Arquivos alterados:**
- `bin/dpp.dart`: Refatorado a chamada da função `showVersion` para transitar entre booleanos e garantir os fluxos `-v` (curto) e `--version` (longo) corretamente.
- `test/cli_version_test.dart` (Novo arquivo): Adicionado para certificar a estabilidade de `-v` e `--version` sob diferentes posições usando subprocessos diretos em testes CLI.

**Impacto em arquivos `.md`:**
Nenhum arquivo `.md` foi atualizado pois o comportamento esperado da aplicação (imprimir versão) permanece o mesmo, o que mudou foi o conserto do fluxo interno que estava lançando uma exceção de Dart não tratada ao invés do texto da documentação.

**Impacto nos testes:**
Adicionei o arquivo de testes automatizado `test/cli_version_test.dart` com quatro cenários confirmando que a versão é exibida e o binário tem `exitCode` de `0` (sucesso) tanto na sua execução padrão como associada a outras flags (`--no-git`). Todos os testes antigos foram mantidos e executados, não ocorrendo nenhuma regressão.

---
*PR created automatically by Jules for task [6553630337957967456](https://jules.google.com/task/6553630337957967456) started by @insign*