### PR TITLE
Fix pubspec inline comment preservation bug during version update

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -216,9 +216,9 @@ class DartPubPublish {
       // Replace the version number in the pubspec.yaml file
       log('Updating version in pubspec.yaml...');
 
-      final updatedPubspecContents = oldPubspecContents.replaceFirst(
-        RegExp(r'^version\s*:.*$', multiLine: true),
-        'version: $newVersion',
+      final updatedPubspecContents = oldPubspecContents.replaceFirstMapped(
+        RegExp(r'^(version\s*:\s*)(.*?)(?=\s*(?:#|$))', multiLine: true),
+        (Match m) => '${m[1]}$newVersion',
       );
 
       _pubspecFile.writeAsStringSync(updatedPubspecContents);

--- a/test/pubspec_preservation_test.dart
+++ b/test/pubspec_preservation_test.dart
@@ -25,7 +25,7 @@ void main() {
 name: my_package
 description: A description.
 # This is a comment
-version: 1.0.0
+version: 1.0.0 # This is an inline comment
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -56,6 +56,7 @@ environment:
 
       // Check comment preservation
       expect(updatedContent, contains('# This is a comment'));
+      expect(updatedContent, contains('version: 1.0.1 # This is an inline comment'));
 
       // Check formatting preservation (empty line)
       expect(updatedContent, contains('\nenvironment:'));


### PR DESCRIPTION
Fix pubspec inline comment preservation bug during version update

The regex used to update the `pubspec.yaml` version was incorrectly capturing and replacing the entire line, wiping out inline comments (e.g. `version: 1.0.0 # comment`). The regex has been updated using `replaceFirstMapped` with a positive lookahead to safely replace only the version value. Tests have been added to prevent regression.

---
*PR created automatically by Jules for task [6683118605570930651](https://jules.google.com/task/6683118605570930651) started by @insign*