### PR TITLE
fix: preserve inline comments in pubspec.yaml version updates

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -216,9 +216,9 @@ class DartPubPublish {
       // Replace the version number in the pubspec.yaml file
       log('Updating version in pubspec.yaml...');
 
-      final updatedPubspecContents = oldPubspecContents.replaceFirst(
-        RegExp(r'^version\s*:.*$', multiLine: true),
-        'version: $newVersion',
+      final updatedPubspecContents = oldPubspecContents.replaceFirstMapped(
+        RegExp(r'^(\s*version\s*:\s*)(.*?)(?=\s*(?:#.*)?$)', multiLine: true),
+        (match) => '${match[1]}$newVersion',
       );
 
       _pubspecFile.writeAsStringSync(updatedPubspecContents);

--- a/test/pubspec_preservation_test.dart
+++ b/test/pubspec_preservation_test.dart
@@ -25,7 +25,7 @@ void main() {
 name: my_package
 description: A description.
 # This is a comment
-version: 1.0.0
+version: 1.0.0 # Do not delete me
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -56,6 +56,9 @@ environment:
 
       // Check comment preservation
       expect(updatedContent, contains('# This is a comment'));
+
+      // Check inline comment preservation
+      expect(updatedContent, contains('version: 1.0.1 # Do not delete me'));
 
       // Check formatting preservation (empty line)
       expect(updatedContent, contains('\nenvironment:'));


### PR DESCRIPTION
Fix: preserve inline comments when updating pubspec.yaml version

This PR changes the regex logic in `dpp_base.dart` to strictly preserve inline comments on the `version` line in `pubspec.yaml`. Previously, if you had `version: 1.0.0 # comment`, the regex would match the entire line and overwrite it completely with `version: 1.0.1`, effectively deleting the comment. By using `replaceFirstMapped` with a non-greedy matcher and positive lookahead, we surgically replace only the version value. 

This brings real value to the Developer Experience (DX) because developers often use comments to leave notes about version syncs or publishing status, and having `dpp` destroy those was an unintended side-effect.

I've also updated `pubspec_preservation_test.dart` to assert that inline comments are preserved properly.

---
*PR created automatically by Jules for task [10423790227026477350](https://jules.google.com/task/10423790227026477350) started by @insign*