### PR TITLE
Fix incorrect updating of nested dependency versions in pubspec.yaml

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -217,7 +217,7 @@ class DartPubPublish {
       log('Updating version in pubspec.yaml...');
 
       final updatedPubspecContents = oldPubspecContents.replaceFirstMapped(
-        RegExp(r'^(\s*version\s*:\s*)(.*?)(?=\s*(?:#.*)?$)', multiLine: true),
+        RegExp(r'^(version\s*:\s*)(.*?)(?=\s*(?:#.*)?$)', multiLine: true),
         (match) => '${match[1]}$newVersion',
       );
 

--- a/test/pubspec_preservation_test.dart
+++ b/test/pubspec_preservation_test.dart
@@ -63,5 +63,47 @@ environment:
       // Check formatting preservation (empty line)
       expect(updatedContent, contains('\nenvironment:'));
     });
+
+    test('does not modify version inside dependencies', () async {
+      final initialContent = '''
+name: my_package
+description: A description.
+
+dependencies:
+  some_dependency:
+    version: 1.0.0
+
+version: 1.0.0
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+''';
+      await pubspecFile.writeAsString(initialContent);
+
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: false,
+          analyze: false,
+          format: false,
+          fix: false,
+          tests: false,
+          pubGet: false,
+          pubspec: true,
+          pubspec2dart: false,
+          pubPublish: false,
+          verbose: false);
+
+      await publish.run('2.0.0', message: 'Update version');
+
+      final updatedContent = pubspecFile.readAsStringSync();
+
+      // Check root version update
+      expect(updatedContent, contains('version: 2.0.0'));
+
+      // Check nested version preservation
+      expect(updatedContent, contains('    version: 1.0.0'));
+    });
   });
 }


### PR DESCRIPTION
Fix incorrect updating of nested dependency versions in pubspec.yaml

The regex used to update the version inside `pubspec.yaml` was incorrectly matching nested `version:` keys (e.g. inside the `dependencies:` block) because it allowed leading whitespace. This led to a bug where `dpp` updated a pinned dependency instead of the root package version.

The regex has been updated from `RegExp(r'^(\s*version\s*:\s*)')` to `RegExp(r'^(version\s*:\s*)')` to strictly match the `version:` key starting exactly at the beginning of the line without any leading whitespace.

A new test case has been added in `test/pubspec_preservation_test.dart` to verify this behavior.

---
*PR created automatically by Jules for task [12726140697523421432](https://jules.google.com/task/12726140697523421432) started by @insign*