### PR TITLE
Fix: regex mistakenly updates nested dependency versions instead of root pubspec version

### DIFF
--- a/lib/src/dpp_base.dart
+++ b/lib/src/dpp_base.dart
@@ -217,7 +217,7 @@ class DartPubPublish {
       log('Updating version in pubspec.yaml...');
 
       final updatedPubspecContents = oldPubspecContents.replaceFirstMapped(
-        RegExp(r'^(\s*version\s*:\s*)(.*?)(?=\s*(?:#.*)?$)', multiLine: true),
+        RegExp(r'^(version\s*:\s*)(.*?)(?=\s*(?:#.*)?$)', multiLine: true),
         (match) => '${match[1]}$newVersion',
       );
 

--- a/test/pubspec_preservation_test.dart
+++ b/test/pubspec_preservation_test.dart
@@ -63,5 +63,43 @@ environment:
       // Check formatting preservation (empty line)
       expect(updatedContent, contains('\nenvironment:'));
     });
+
+    test('updates root version and ignores nested dependency version', () async {
+      final initialContent = '''
+name: my_package
+description: A description.
+
+dependencies:
+  some_package:
+    version: 1.0.0
+
+version: 1.0.0
+''';
+      await pubspecFile.writeAsString(initialContent);
+
+      final publish = DartPubPublish(
+          pubspecFile: pubspecFile.path,
+          changeLogFile: changeLogFile.path,
+          workingDir: tempDir.path,
+          git: false,
+          analyze: false,
+          format: false,
+          fix: false,
+          tests: false,
+          pubGet: false,
+          pubspec: true,
+          pubspec2dart: false,
+          pubPublish: false,
+          verbose: false);
+
+      await publish.run('2.0.0', message: 'Update root version');
+
+      final updatedContent = pubspecFile.readAsStringSync();
+
+      // Ensure root version is updated
+      expect(updatedContent, contains('version: 2.0.0'));
+      // Ensure nested version is intact
+      expect(updatedContent, contains('    version: 1.0.0'));
+    });
   });
 }


### PR DESCRIPTION
Fixes a bug where `dpp` would update a nested dependency's `version:` attribute in `pubspec.yaml` instead of the root `version:` attribute, if the dependency appeared before the root version. By making the regex strictly match the root `version:` (which has no leading whitespace in YAML), it correctly targets the main package version. Included regression tests verify this behavior.

---
*PR created automatically by Jules for task [11219593149291517319](https://jules.google.com/task/11219593149291517319) started by @insign*